### PR TITLE
feat: cli treemap & statistics export

### DIFF
--- a/packages/cli/src/main.ts
+++ b/packages/cli/src/main.ts
@@ -16,3 +16,5 @@ cli.runExit(process.argv.slice(2), Cli.defaultContext)
 
 export * from './notion/export'
 export * from './notion/index'
+export * from './treemap'
+export * from './stats'

--- a/packages/cli/src/notion/export.ts
+++ b/packages/cli/src/notion/export.ts
@@ -1,5 +1,7 @@
 import { Option, Command } from 'clipanion'
 import { NotionExporter } from './index'
+import { generateTreemaps, PageNode } from '../treemap'
+import { computeStats, writeStats } from '../stats'
 
 export class NotionExportCommand extends Command {
   static paths = [['export']]
@@ -38,6 +40,12 @@ export class NotionExportCommand extends Command {
   dataset = Option.Boolean('-d, --dataset', {
     description: 'Export as dataset for LLM learning'
   })
+  treemap = Option.Boolean('--treemap', {
+    description: 'Generate HTML treemap after export'
+  })
+  stats = Option.Boolean('--stats', {
+    description: 'Generate statistics JSON after export'
+  })
   token = Option.String('-t,--token', {
     description: 'Notion Access Token'
   })
@@ -59,5 +67,15 @@ export class NotionExportCommand extends Command {
       token: this.token
     })
     await exporter.execute()
+
+    if (this.treemap || this.stats) if (!exporter.pageTree) await exporter.loadRaw()
+
+    const tree = exporter.pageTree as unknown as PageNode
+    if (this.treemap && tree) await generateTreemaps(this.folder, tree)
+
+    if (this.stats && tree) {
+      const stats = computeStats(tree)
+      await writeStats(`${this.folder}/stats.json`, stats)
+    }
   }
 }

--- a/packages/cli/src/stats.ts
+++ b/packages/cli/src/stats.ts
@@ -1,0 +1,28 @@
+import type { PageNode } from './treemap'
+
+export interface ExportStats {
+  totalPages: number
+  totalBlocks: number
+  maxDepth: number
+}
+
+export function computeStats(pageTree: PageNode): ExportStats {
+  let totalPages = 0
+  let totalBlocks = 0
+  let maxDepth = 0
+
+  function traverse(node: PageNode, depth: number) {
+    totalPages += node.pages || 0
+    totalBlocks += node.blocks || 0
+    if (depth > maxDepth) maxDepth = depth
+    if (node.children) for (const child of node.children) traverse(child, depth + 1)
+  }
+
+  traverse(pageTree, 1)
+  return { totalPages, totalBlocks, maxDepth }
+}
+
+export async function writeStats(file: string, stats: ExportStats) {
+  const fs = await import('fs/promises')
+  await fs.writeFile(file, JSON.stringify(stats, null, 2), 'utf8')
+}

--- a/packages/cli/src/treemap.ts
+++ b/packages/cli/src/treemap.ts
@@ -1,10 +1,7 @@
 import fs from 'fs'
 import { promisify } from 'util'
-import { loadRaw } from './notion'
 
-const writeFile = promisify(fs.writeFile)
-
-interface PageNode {
+export interface PageNode {
   id: string
   blocks: number
   pages: number
@@ -12,22 +9,18 @@ interface PageNode {
   children?: PageNode[]
 }
 
-async function main() {
-  const { pageTree } = await loadRaw('texonom-raw')
+const writeFile = promisify(fs.writeFile)
 
-  // Generate treemap for page counts
+export async function generateTreemaps(folder: string, pageTree: PageNode) {
   const treemapDataPages = computeMetrics(pageTree, 'pages')
   const titlePages = 'Texonom PageTree'
-  const outputPathPages = 'texonom-raw/pagetree.html'
+  const outputPathPages = `${folder}/pagetree.html`
   await generateTreemapHTML(treemapDataPages, titlePages, outputPathPages)
 
-  // Generate treemap for block counts
   const treemapDataBlocks = computeMetrics(pageTree, 'blocks')
   const titleBlocks = 'Texonom BlockMap'
-  const outputPathBlocks = 'texonom-raw/blocktree.html'
+  const outputPathBlocks = `${folder}/blocktree.html`
   await generateTreemapHTML(treemapDataBlocks, titleBlocks, outputPathBlocks)
-
-  console.info('Treemap HTML files generated successfully.')
 }
 
 interface TreemapNode {
@@ -353,5 +346,3 @@ async function generateTreemapHTML(data: TreemapNode, title: string, outputPath:
 
   await writeFile(outputPath, htmlContent, 'utf8')
 }
-
-main().catch(error => console.error(error))


### PR DESCRIPTION
## Summary
- add options to generate HTML treemaps and export statistics
- expose treemap and stats helpers

## Testing
- `pnpm test` *(fails: Failed to resolve entry for package `@texonom/nutils`)*

------
https://chatgpt.com/codex/tasks/task_e_6842cb124838832782b7b87eb880065d