### PR TITLE
Add push option to export CLI

### DIFF
--- a/packages/cli/src/notion/export.ts
+++ b/packages/cli/src/notion/export.ts
@@ -44,6 +44,9 @@ export class NotionExportCommand extends Command {
   wait = Option.Counter('-w,--wait', {
     description: 'Wait couter for missed collection view'
   })
+  push = Option.Boolean('--push', {
+    description: 'Push exported data to remote repositories'
+  })
 
   async execute() {
     const exporter = new NotionExporter({
@@ -56,8 +59,10 @@ export class NotionExportCommand extends Command {
       load: this.load,
       raw: this.raw,
       dataset: this.dataset,
-      token: this.token
+      token: this.token,
+      push: this.push
     })
     await exporter.execute()
+    if (this.push) await exporter.push()
   }
 }


### PR DESCRIPTION
## Summary
- add `--push` flag to export command
- allow NotionExporter to push exported content to `texonom-raw` and `texonom-md`

## Testing
- `pnpm test` *(fails: vitest not found)*
- `pnpm lint` *(fails: eslint command issue)*

------
https://chatgpt.com/codex/tasks/task_e_6842d06cc8908327aba1258d471728c9