### PR TITLE
Add TypeScript release script

### DIFF
--- a/release.ts
+++ b/release.ts
@@ -1,0 +1,30 @@
+#!/usr/bin/env tsx
+/* eslint-disable no-console */
+import { execSync } from 'node:child_process'
+
+function run(cmd: string): void {
+  console.log(`\n$ ${cmd}`)
+  execSync(cmd, { stdio: 'inherit', shell: true })
+}
+
+const arg = process.argv.find(a => a.startsWith('--version='))
+if (!arg) {
+  console.error('Usage: release.ts --version=<VERSION>')
+  process.exit(1)
+}
+const version = arg.split('=')[1]
+if (!version) {
+  console.error('Invalid version.')
+  process.exit(1)
+}
+
+run('pnpm build')
+run('pnpm test')
+run(`pnpm release ${version}`)
+run(`pnpm turbo release -- ${version}`)
+run('pnpm format')
+run(`git commit -am "meta: deployment commit for ${version}"`)
+run(`git tag ${version}`)
+run('pnpm turbo pu')
+run('git push')
+run('git push --tags')

--- a/release.ts
+++ b/release.ts
@@ -18,13 +18,19 @@ if (!version) {
   process.exit(1)
 }
 
-run('pnpm build')
-run('pnpm test')
-run(`pnpm release ${version}`)
-run(`pnpm turbo release -- ${version}`)
-run('pnpm format')
-run(`git commit -am "meta: deployment commit for ${version}"`)
-run(`git tag ${version}`)
-run('pnpm turbo pu')
-run('git push')
-run('git push --tags')
+const commands = [
+  'pnpm build',
+  'pnpm test',
+  `pnpm release ${version}`,
+  `pnpm turbo release -- ${version}`,
+  'pnpm format',
+  `git commit -am "meta: deployment commit for ${version}"`,
+  `git tag ${version}`,
+  'pnpm turbo pu',
+  'git push',
+  'git push --tags',
+];
+
+for (const cmd of commands) {
+  run(cmd);
+}


### PR DESCRIPTION
## Summary
- convert `release.js` helper to TypeScript

## Testing
- `pnpm install`
- `pnpm test` *(fails: Failed to resolve entry for package `@texonom/nutils`)*

------
https://chatgpt.com/codex/tasks/task_e_6843006a2eac8327a5347436446ca9c8