### PR TITLE
docs: enrich package usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,38 +2,74 @@
 
 ![downloads](https://img.shields.io/npm/d18m/%40texonom%2Fnclient)
 
-This repository is fork of [React Notion X](https://github.com/NotionX/react-notion-x).
-Refactored with [Turboplate](https://github.com/seonglae/turboplate). Search API, Backlinks and Property rendering are maintained in this project.
+A **TypeScript-first** toolkit for working with Notion. This project began as a fork of [React Notion X](https://github.com/NotionX/react-notion-x) and adds features like a **search API**, **backlink** support and extended property rendering. Everything is bundled as a monorepo containing small focused packages.
+
+## Features
+
+- Search API with backlink support
+- Extended property rendering
+- CLI exporter and React renderer
+- Works in Node.js and the browser
 
 ![Property](image/property.png)
 
-# Modules
+## Difference from React Notion X
 
-- `@texonom/ntypes`
-- `@texonom/nclient`
-- `@texonom/ncompat`
-- `@texonom/nutils`
-- `@ntexonom/nreact`
+The original project focuses on rendering Notion pages. Texonom Notion adds a custom client with search and backlink APIs, an exporter CLI and improved property handling.
 
-# Development
+## Packages
 
-```zsh
-pnpm i
-pnpm build # TSUp
-pnpm test # Vitest
+- **`@texonom/ntypes`** – shared TypeScript definitions
+- **`@texonom/nclient`** – Node/Deno client for the unofficial Notion API
+- **`@texonom/ncompat`** – compatibility layer for the official API
+- **`@texonom/nutils`** – utility functions for Notion data
+- **`@texonom/nreact`** – React renderer built on top of the above
+- **`@texonom/cli`** – CLI for exporting pages and workspaces
+
+## Quick example
+
+```ts
+import { NotionAPI } from '@texonom/nclient'
+import { NotionRenderer } from '@texonom/nreact'
+
+const api = new NotionAPI()
+const recordMap = await api.getPage('PAGE_ID')
+
+<NotionRenderer recordMap={recordMap} fullPage />
 ```
 
-# Deployment
+```ts
+import { parsePageId } from '@texonom/nutils'
+parsePageId('About-d9ae0c6e7cad49a78e21d240cf2e3d04')
+// 'd9ae0c6e7cad49a78e21d240cf2e3d04'
+```
 
-Version update in `package.json` is automated by `standard-version`
+See it live at [texonom.com](https://texonom.com).
 
-## Release
+### Export via CLI
 
-```zsh
-# check terminal pwd project root
+```bash
+pnpm tsx packages/cli/src/main.ts export -p 04089c8ae3534bf79512fc495944b321 --raw -r -f
+```
+
+## Development
+
+```bash
+pnpm i
+pnpm build  # tsup
+pnpm test   # vitest
+```
+
+## Deployment
+
+Version updates are automated via `standard-version`.
+
+### Release
+
+```bash
 pnpm build && pnpm test
-VERSION=
-pnpm release $VERSION # Apply workspace
+VERSION=<new version>
+pnpm release $VERSION
 pnpm turbo release -- $VERSION
 pnpm format
 git commit -am "meta: deployment commit for $VERSION"
@@ -42,25 +78,28 @@ pnpm turbo pu
 git push && git push --tags
 ```
 
-## Prerelease
+### Prerelease
 
-```zsh
+```bash
 pnpm build && pnpm test
-VERSION=alpha or beta or rc
-pnpm prerelease $VERSION # Apply workspace
+VERSION=<alpha|beta|rc>
+pnpm prerelease $VERSION
 pnpm turbo prerelease -- $VERSION
 git commit -am "meta: deployment commit for $VERSION"
 pnpm turbo pu
 ```
 
-# Built with
+## Contributing
 
-[Turboplate](https://github.com/seonglae/turboplate) stacks
+1. Fork the repo and create a feature branch.
+2. `pnpm i` to install dependencies.
+3. Run `pnpm build` and `pnpm test` before opening a pull request.
 
-- `Turborepo` monorepo
-- `TSup` build
-- `Vitest` test
-- `ESLint` lint
-- `Prettier` format
-- `Husky` git hook
-- `Standard Version` release
+## Built with
+
+- **Turborepo** for monorepo management
+- **TSup** for builds
+- **Vitest** for tests
+- **ESLint** and **Prettier** for code style
+- **Husky** git hooks
+- **Standard Version** for releases

--- a/packages/cli/readme.md
+++ b/packages/cli/readme.md
@@ -1,8 +1,14 @@
 # Texonom Notion CLI
 
-> Robust TypeScript client for the unofficial Notion API.
+Command line interface for exporting Notion data. It wraps the `@texonom/nclient` library and converts pages or entire workspaces to Markdown.
 
 [![NPM](https://img.shields.io/npm/v/@texonom/cli.svg)](https://www.npmjs.com/package/@texonom/cli) [![Build Status](https://github.com/texonom/notion-node/actions/workflows/test.yml/badge.svg)](https://github.com/texonom/notion-node/actions/workflows/test.yml) [![Prettier Code Formatting](https://img.shields.io/badge/code_style-prettier-brightgreen.svg)](https://prettier.io)
+
+## Features
+
+- Export a single page or an entire workspace
+- Output raw Notion data or rendered Markdown
+- Handles rate limits and supports auth tokens
 
 ## Install
 
@@ -10,16 +16,16 @@
 pnpm i @texonom/cli
 ```
 
-# Usages
+## Usage
 
-## Export
+### Export
 
-```zsh
-## export block, collection, collection_view and notion_user for each folder
+```bash
+# export block, collection, collection_view and notion_user for each folder
 pnpm tsx src/main.ts export --raw
 ```
 
-# Develop
+### Programmatic use
 
 ```ts
 import { NotionExporter } from '@texonom/cli'
@@ -29,31 +35,54 @@ const recordMap = await exporter.notion.getPage(pageId)
 const md = await exporter.pageToMarkdown(parsePageId(pageId), recordMap)
 ```
 
-### Example
+```ts
+// also works with page URLs thanks to nutils
+import { parsePageId } from '@texonom/nutils'
 
-Export whole workspace
+const exporter = new NotionExporter({ page })
+const recordMap = await exporter.notion.getPage(page)
+const md = await exporter.pageToMarkdown(parsePageId(page), recordMap)
+```
 
-```sh
-# 1. First get all raw data from the Notion API
+### Example workflow
+
+```bash
+# 1. Fetch raw data from Notion
 pnpm tsx src/main.ts export -p 04089c8ae3534bf79512fc495944b321 --raw -r -f
 
-# 2. After that transform all raw data to markdown
-# it requres Notion token if there are missed blocks & spaces & users & collections (No ~ query)
+# 2. Transform raw data to markdown (requires token if data is private)
 export NOTION_TOKEN=
 pnpm tsx src/main.ts export -p 04089c8ae3534bf79512fc495944b321 -r -l -t $NOTION_TOKEN -u
-# 3. If there is a rate limit error try without token for anonymous request
+
+# 3. Retry without token if you hit rate limits
 pnpm tsx src/main.ts export -p 04089c8ae3534bf79512fc495944b321 -r -l -u
-# Iterate the 2-3 commands until collection error is gone (due to the rate limit)
 ```
 
-if there is memory error
+If you encounter memory errors:
 
-```
+```bash
 NODE_OPTIONS="--max-old-space-size=16384" tsx ...
 ```
 
-Export a single page
+### Export a single page
 
-```sh
+```bash
 pnpm tsx src/main.ts export -p 04089c8ae3534bf79512fc495944b321
 ```
+
+## API
+
+Exports:
+
+- `NotionExportCommand` CLI entry
+- `NotionExporter` class
+- `getBlockLink(blockId, recordMap)`
+- `loadRaw(folder)`
+- `loadJson(folder, file)`
+- `generateTreemaps(folder, pageTree)`
+- `computeStats(pageTree)`
+- `writeStats(file, stats)`
+
+## Difference from React Notion X
+
+The original project focuses on rendering. This CLI adds a straightforward way to download and convert Notion content from the terminal.

--- a/packages/nclient/readme.md
+++ b/packages/nclient/readme.md
@@ -1,8 +1,15 @@
 # nclient
 
-> Robust TypeScript client for the unofficial Notion API.
+Robust TypeScript client for the unofficial Notion API, featuring a **search API** and **backlink** helpers.
 
 [![NPM](https://img.shields.io/npm/v/@texonom/nclient.svg)](https://www.npmjs.com/package/@texonom/nclient) [![Build Status](https://github.com/texonom/notion-node/actions/workflows/test.yml/badge.svg)](https://github.com/texonom/notion-node/actions/workflows/test.yml) [![Prettier Code Formatting](https://img.shields.io/badge/code_style-prettier-brightgreen.svg)](https://prettier.io)
+
+## Features
+
+- Works in Node.js, Deno and Cloudflare Workers
+- Fetch pages, collections and search results
+- Backlink API for discovering references
+- Supports signed URLs for hosted assets
 
 ## Install
 
@@ -10,155 +17,84 @@
 pnpm i @texonom/nclient
 ```
 
-This package is compatible with server-side V8 contexts such as Node.js, Deno, and Cloudflare Workers.
+This package is compatible with server-side V8 contexts such as Node.js, Deno and Cloudflare Workers.
 
 ## Usage
 
 ```ts
-import { NotionAPI } from 'nclient'
+import { NotionAPI } from '@texonom/nclient'
 
-// you can optionally pass an authToken to access private notion resources
-const api = new NotionAPI()
+// you can optionally pass an authToken to access private pages
+const api = new NotionAPI({ authToken: process.env.NOTION_TOKEN })
 
-// fetch a page's content, including all async blocks, collection queries, and signed urls
+// fetch a page's content, including collection data and signed urls
 const page = await api.getPage('067dd719-a912-471e-a9a3-ac10710e7fdf')
-
-// fetch the data for a specific collection instance
-const collectionId = '2d8aec23-8281-4a94-9090-caaf823dd21a'
-const collectionViewId = 'ab639a5a-853e-45e1-9ef7-133b486c0acf'
-const collectionData = await api.getCollectionData(collectionId, collectionViewId)
 ```
-
-### Fetch backlinks
-
-Backlinks require an auth token.
 
 ```ts
-const backlinks = await api.getBacklinks({
-  block: { id: 'page-id', spaceId: 'space-id' }
+// fetch user and workspace info
+const users = await api.getUsers(['user-id'])
+const spaces = await api.getSpaces(['space-id'])
+```
+
+### Backlinks
+
+```ts
+const backlinks = await api.getBacklinks({ block: { id: 'page-id', spaceId: 'space-id' } })
+```
+
+### Fetch collection data
+
+```ts
+const data = await api.getCollectionData('collection-id', 'collection-view-id')
+```
+
+### Search
+
+```ts
+const results = await api.search({
+  query: 'Texonom',
+  spaceId: '0bf522c6-2468-4c71-99e3-68f5a25d4225',
+  filters: {
+    ancestors: ['04089c8ae3534bf79512fc495944b321'],
+    isDeletedOnly: false,
+    excludeTemplates: true,
+    navigableBlockContentOnly: true,
+    requireEditPermissions: false
+  }
 })
-
-// or simply pass the page id
-const pageBacklinks = await api.getPageBacklinks('page-id')
 ```
 
-### Fetch a database's content
+### Get blocks
 
-You can pass a database ID to the `getPage` method. The response is an object which contains several important properties:
-
-- `block`
-- `collection`
-- `collection_view`
-
-The value of the `block` property maps the id of each block object present in the database to its corresponding properties like type, parent id, created time, last edited by, and more.
-
-```
-{
-  block: {
-    'cc368b47-772a-4a1a-a36e-1f52c507d20d': { role: 'reader', value: [Object] },
-    '97dbe6d5-aea3-4e03-b571-91810cf975d4': { role: 'reader', value: [Object] },
-    '08d5ba1e-03d2-4d4a-add7-a414f297ff8a': { role: 'reader', value: [Object] },
-    '7aad4627-c4af-4314-960e-1465e76cc6bd': { role: 'reader', value: [Object] },
-    '7be73360-19b9-4b77-a518-70acd610d492': { role: 'reader', value: [Object] },
-    'af961803-cd0c-470e-bd27-1d025baa2f95': { role: 'reader', value: [Object] },
-    // ...
-  }
-}
+```ts
+const res = await api.getBlocks(['3f9e0d86-c643-4672-aa0c-78d63fa80598'])
 ```
 
-The map of blocks is arranged as followed:
+### Signed file URLs
 
-- The first id is of the collection view
-- The second is of the parent page that contains the database in question
-- The next ids are of all the children pages inside the database
-- After that comes all the children blocks of each page.
-
-Please note that a block object can take many types: header, text, list, media, and almost any block supported by Notion. It can also be _a page_ or a _collection view_.
-
-Example of a block object of type `text`:
-
-```
-{
-  role: 'reader',
-  value: {
-    id: '0377e1a4-dc3d-4daf-99dd-f54f986d932e',
-    version: 1,
-    type: 'text',
-    properties: { title: [Array] },
-    format: { copied_from_pointer: [Object] },
-    created_time: 1655961814278,
-    last_edited_time: 1655961814278,
-    parent_id: '08d5ba1e-03d2-4d4a-add7-a414f297ff8a',
-    parent_table: 'block',
-    alive: true,
-    copied_from: '526d2008-0d0b-46f8-9de1-7411a85bff7b',
-    created_by_table: 'notion_user',
-    created_by_id: '55b29a2b-a8fe-4a11-9f9d-ada341bd922b',
-    last_edited_by_table: 'notion_user',
-    last_edited_by_id: '55b29a2b-a8fe-4a11-9f9d-ada341bd922b',
-    space_id: '6b70425f-211e-4318-80c6-5d093df8f7eb'
-  }
-}
+```ts
+const signed = await api.getSignedFileUrls(['https://prod-files.example/notion.png'])
 ```
 
-Example of a block object of type `page`:
+See the [full docs](https://github.com/texonom/notion-node) for more examples.
 
-```
-{
-  role: 'reader',
-  value: {
-    id: 'af961803-cd0c-470e-bd27-1d025baa2f95',
-    version: 31,
-    type: 'page',
-    properties: { '==~K': [Array], 'BN]P': [Array], title: [Array] },
-    content: [
-      '8cbf7053-da37-4d69-8cde-89343baf3623',
-      '0fc1712e-852c-4307-b72b-094dadaa86ba'
-    ],
-    created_time: 1655962200000,
-    last_edited_time: 1655979420000,
-    parent_id: '175482e5-870d-4da8-980c-ead469427316',
-    parent_table: 'collection',
-    alive: true,
-    created_by_table: 'notion_user',
-    created_by_id: '55b29a2b-a8fe-4a11-9f9d-ada341bd922b',
-    last_edited_by_table: 'notion_user',
-    last_edited_by_id: '55b29a2b-a8fe-4a11-9f9d-ada341bd922b',
-    space_id: '6b70425f-211e-4318-80c6-5d093df8f7eb'
-  }
-}
-```
+## API
 
-Example of a block object of type `collection_view`:
+The `NotionAPI` class exposes the following methods:
 
-```
-{
-  role: 'reader',
-  value: {
-    id: 'cc368b47-772a-4a1a-a36e-1f52c507d20d',
-    version: 5,
-    type: 'collection_view',
-    view_ids: [
-      '028f6968-2a6c-46da-bf43-cb44e6d91765',
-      '77f32047-52dd-422e-93fa-813438087e57'
-    ],
-    collection_id: '175482e5-870d-4da8-980c-ead469427316',
-    format: { collection_pointer: [Object], copied_from_pointer: [Object] },
-    created_time: 1655961814276,
-    last_edited_time: 1656075900000,
-    parent_id: '97dbe6d5-aea3-4e03-b571-91810cf975d4',
-    parent_table: 'block',
-    alive: true,
-    copied_from: '3e3073e9-7aee-481c-b831-765e112ec7b5',
-    created_by_table: 'notion_user',
-    created_by_id: '55b29a2b-a8fe-4a11-9f9d-ada341bd922b',
-    last_edited_by_table: 'notion_user',
-    last_edited_by_id: '55b29a2b-a8fe-4a11-9f9d-ada341bd922b',
-    space_id: '6b70425f-211e-4318-80c6-5d093df8f7eb'
-  }
-}
-```
+- `getPage(id, opts?)`
+- `fetchCollections(blockIds, recordMap, pageId?, opts?)`
+- `addSignedUrls({ recordMap, contentBlockIds })`
+- `getPageRaw(id, opts?)`
+- `getCollectionData(collectionId, viewId, opts?)`
+- `getUsers(ids)`
+- `getSpaces(ids)`
+- `getBlocks(ids)`
+- `syncRecords(records)`
+- `getSignedFileUrls(urls)`
+- `search(params)`
+- `getBacklinks(params)`
 
-## Docs
-
-See the [full docs](https://github.com/texonom/notion-node).
+Types such as `SignedUrlRequest` and `FetchOption` are also exported.
+\n## Difference from the official API\n\nThis client mirrors the format of the unofficial API and exposes additional helpers like `search` and `getBacklinks`.

--- a/packages/ncompat/readme.md
+++ b/packages/ncompat/readme.md
@@ -6,6 +6,8 @@
 
 ## Features
 
+- Uses the official Notion API while keeping the response structure of the unofficial API
+
 - fully compatible with `nreact`
 - backwards compatible with `nclient` and the unofficial notion API
 
@@ -20,7 +22,27 @@ const notion = new NotionCompatAPI(new Client({ auth: process.env.NOTION_TOKEN }
 const recordMap = await notion.getPage(pageId)
 ```
 
+```ts
+// searching works too
+const results = await notion.search({ query: 'Texonom' })
+```
+
 The resulting `recordMap` is compatible with notion's unofficial API and nreact.
+
+## API
+
+Exports:
+
+- `NotionCompatAPI` – wrapper around '@notionhq/client'
+- `convertPage({ pageId, blockMap })`
+- `convertBlock({ block, blockMap })`
+- `convertTime(time)`
+- `convertColor(color)`
+- `convertRichText(rich)`
+
+## Difference from React Notion X
+
+This layer lets you use the official API while retaining the features of the original unofficial client.
 
 ## Demo
 

--- a/packages/nreact/readme.md
+++ b/packages/nreact/readme.md
@@ -1,19 +1,59 @@
 # React Notion X
 
-> Fast and accurate React renderer for Notion.
+Fast and accurate React renderer for Notion.
 
 [![NPM](https://img.shields.io/npm/v/@texonom/nreact.svg)](https://www.npmjs.com/package/@texonom/nreact) [![Build Status](https://github.com/texonom/notion-node/actions/workflows/test.yml/badge.svg)](https://github.com/texonom/notion-node/actions/workflows/test.yml) [![Prettier Code Formatting](https://img.shields.io/badge/code_style-prettier-brightgreen.svg)](https://prettier.io)
 
-## Docs
+## Features
 
-See the [full docs](https://github.com/texonom/notion-node).
+- Render pages from `@texonom/nclient` or `@texonom/ncompat` record maps
+- Built-in search dialog and Table of Contents
+- Lightweight components with sensible defaults
+
+Use the renderer as a drop-in component or import pieces for your own UI.
+
+## Usage
+
+```tsx
+import { NotionRenderer } from '@texonom/nreact'
+;<NotionRenderer recordMap={recordMap} fullPage />
+```
+
+```tsx
+// customize links and image urls
+<NotionRenderer
+  recordMap={recordMap}
+  fullPage
+  mapPageUrl={id => `/docs/${id}`}
+  mapImageUrl={url => `/api/image/${encodeURIComponent(url)}`}
+  components={{
+    nextLink: ({ href, children }) => <a href={href}>{children}</a>
+  }}
+/>
+```
+
+```tsx
+// use a single component
+import { Text } from '@texonom/nreact'
+
+function Title({ value }) {
+  return <Text value={value} />
+}
+```
+
+## API
+
+Exports:
+
+- `NotionRenderer`
+- block components like `Text`, `Header`, `PageIcon`, `PageAside` and more
+- helper hooks and context
+
+## Difference from the original
+
+This fork keeps the renderer from React Notion X but integrates extra features such as backlink rendering and improved property display.
 
 ## Source code
 
-### `block.tsx`
-
-for block type switch case
-
-### `text.tsx`
-
-for decoration switch case
+- `block.tsx` – block type switch
+- `text.tsx` – decoration switch

--- a/packages/ntypes/readme.md
+++ b/packages/ntypes/readme.md
@@ -1,8 +1,13 @@
 # ntypes
 
-> TypeScript types for core Notion data structures.
+TypeScript types for core Notion data structures.
 
 [![NPM](https://img.shields.io/npm/v/@texonom/ntypes.svg)](https://www.npmjs.com/package/@texonom/ntypes) [![Build Status](https://github.com/texonom/notion-node/actions/workflows/test.yml/badge.svg)](https://github.com/texonom/notion-node/actions/workflows/test.yml) [![Prettier Code Formatting](https://img.shields.io/badge/code_style-prettier-brightgreen.svg)](https://prettier.io)
+
+## Features
+
+- Strict typings for blocks, users and search results
+- Shared between all packages in this monorepo
 
 ## Install
 
@@ -10,14 +15,36 @@
 pnpm i @texonom/ntypes
 ```
 
-This package only exports types and is compatible with both Node.js and browsers.
-
 ## Usage
 
 ```ts
-import type {} from '@texonom/ntypes'
+import type { ExtendedRecordMap } from '@texonom/ntypes'
+
+function handle(record: ExtendedRecordMap) {
+  console.log(record.block)
+}
 ```
 
-## Docs
+```ts
+import type { Block } from '@texonom/ntypes/block'
 
-See the [full docs](https://github.com/texonom/notion-node).
+const block: Block = {
+  id: 'id',
+  type: 'text'
+  // ...
+}
+```
+
+See the [full docs](https://github.com/texonom/notion-node) for details.
+
+## API
+
+This package re-exports grouped type definitions:
+
+- `core` – shared base types
+- `block` – block data
+- `user` – user information
+- `collection` and `collection-view`
+- `formula` and `maps`
+- `api` request/response shapes
+- `space` workspace info

--- a/packages/nutils/readme.md
+++ b/packages/nutils/readme.md
@@ -1,16 +1,20 @@
 # nutils
 
-> Useful utilities for working with Notion data. Isomorphic.
+Useful utilities for working with Notion data. Runs in Node.js and the browser.
 
 [![NPM](https://img.shields.io/npm/v/@texonom/nutils.svg)](https://www.npmjs.com/package/@texonom/nutils) [![Build Status](https://github.com/texonom/notion-node/actions/workflows/test.yml/badge.svg)](https://github.com/texonom/notion-node/actions/workflows/test.yml) [![Prettier Code Formatting](https://img.shields.io/badge/code_style-prettier-brightgreen.svg)](https://prettier.io)
+
+## Features
+
+- Convert between page IDs and UUIDs
+- Map and normalize Notion URLs
+- Helpers for reading page metadata
 
 ## Install
 
 ```bash
 pnpm i @texonom/nutils
 ```
-
-This package is compatible with both Node.js and client-side web usage.
 
 ## Usage
 
@@ -20,13 +24,50 @@ import { parsePageId } from '@texonom/nutils'
 parsePageId('https://www.notion.so/Notion-Tests-067dd719a912471ea9a3ac10710e7fdf')
 // '067dd719-a912-471e-a9a3-ac10710e7fdf'
 
-parsePageId('About-d9ae0c6e7cad49a78e21d240cf2e3d04')
-// 'd9ae0c6e-7cad-49a7-8e21-d240cf2e3d04'
-
 parsePageId('About-d9ae0c6e7cad49a78e21d240cf2e3d04', { uuid: false })
 // 'd9ae0c6e7cad49a78e21d240cf2e3d04'
+
+import { normalizeUrl } from '@texonom/nutils'
+normalizeUrl('https://test.com/foo/bar?foo=bar')
+
+import { defaultMapPageUrl, defaultMapImageUrl } from '@texonom/nutils'
+const mapPage = defaultMapPageUrl('root')('067dd719a912471ea9a3ac10710e7fdf')
+const mapImage = defaultMapImageUrl('/image.png', { id: 'id', parent_table: 'block' } as any)
+
+import { getCanonicalPageId } from '@texonom/nutils'
+getCanonicalPageId('067dd719-a912-471e-a9a3-ac10710e7fdf', recordMap)
 ```
 
-## Docs
+See the [full docs](https://github.com/texonom/notion-node) for more helpers.
 
-See the [full docs](https://github.com/texonom/notion-node).
+## API
+
+The library exports many helpers. Each function works both in Node.js and the browser.
+
+- `getTextContent(value)` – extract plain text from rich text values
+- `getBlockTitle(block, recordMap)` – title of a block
+- `getBlockIcon(block, recordMap)` – icon for a block
+- `getBlockCollectionId(block, recordMap)` – collection id for collection view blocks
+- `getPageTitle(recordMap)` – page title from a record map
+- `getPageProperty(name, block, recordMap)` – any page property
+- `getDateValue(value)` – normalize Notion date values
+- `getBlockParentPage(block, recordMap)` – parent page block
+- `getPageTableOfContents(recordMap)` – extract headers and links
+- `getPageContentBlockIds(recordMap)` – list of block ids contained in a page
+- `parsePageId(id, opts?)` – convert Notion URLs and ids
+- `idToUuid(id)` – add dashes to a notion id
+- `uuidToId(uuid)` – remove dashes from a uuid
+- `getAllInSpace(api, spaceId)` – fetch every page in a workspace
+- `getCanonicalPageId(pageId, recordMap)` – canonical slug for a page
+- `getPageBreadcrumbs(block, recordMap)` – breadcrumb labels
+- `getPageImageUrls(recordMap)` – all images used on a page
+- `isUrl(value)` – check if a string is a URL
+- `normalizeUrl(url)` – remove tracking params
+- `normalizeTitle(title)` – cleanup page titles
+- `mergeRecordMaps(a, b)` – combine multiple record maps
+- `formatDate(value)` – format ISO date string
+- `formatNotionDateTime(value)` – format Notion timestamps
+- `findAncestors(blockId, recordMap)` – walk up the block tree
+- `estimatePageReadTime(recordMap)` – count words for read time
+- `mapImageUrl(url, block)` – default image URL mapper
+- `mapPageUrl(id)` – default page URL mapper


### PR DESCRIPTION
## Summary
- link texonom.com in the root quick example and add contributing section
- show fetching users and spaces with `NotionAPI`
- illustrate importing single components in nreact
- add more examples of ntypes

## Testing
- `pnpm build`
- `pnpm test` *(fails: fetch failed)*

------
https://chatgpt.com/codex/tasks/task_e_68460cc7af508327933c23c980a91e4c